### PR TITLE
fix for polling selenium server start in version 2.43 and above

### DIFF
--- a/tasks/selenium_server.js
+++ b/tasks/selenium_server.js
@@ -105,7 +105,8 @@ module.exports = function (grunt) {
 
     var complete = false;
 
-    childProcesses[target].stdout.on('data', function(data) {
+    // Reading stream see if selenium has started
+    function hasSeleniumStarted(data) {
       if (data.toString().match(/Started SocketListener on .+:\d+/)) {
         if (complete) return;
         grunt.log.ok('Selenium server SocketListener started.');
@@ -116,13 +117,12 @@ module.exports = function (grunt) {
           cb(null);
         }, 2000);
       }
-    });
-
-    if(options.showErrors || options.showErrors == undefined){
-      childProcesses[target].stderr.on('data', function(data) {
-        grunt.log.error(data.toString());
-      });
     }
+
+    // < 2.43.0 outputs to stdout
+    childProcesses[target].stdout.on('data', hasSeleniumStarted);
+    // >= 2.43.0 outputs to stdout
+    childProcesses[target].stderr.on('data', hasSeleniumStarted);
 
     // Timeout case
     setTimeout(function() {


### PR DESCRIPTION
In selenium server 2.43 and above output is now streamed to stderr. This update will monitor both stderr and stdout for started socket notification so that the plugin will work with selenium server >= 2.43 and still be backward compatible.  

I've also removed the grunt logging of stderr messages as everything is logged there now by selenium. 
