### PR TITLE
added load drivers clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "grunt-contrib-nodeunit": "~0.2.2"
   },
   "dependencies": {
+    "async": "^0.9.0",
+    "progress": "~1.1.2",
     "request": "~2.27.0",
-    "progress": "~1.1.2"
+    "unzip": "^0.1.11"
   }
 }


### PR DESCRIPTION
The first time I modify a plug-in for the grant. in this may be a mistake in the code.

There is a idea to make not only download the file of server, and download drivers for browsers.
But there are some problems with this decision:

1) long loading of the server if the file is downloading from the Internet (about 2 minutes). I can't determine why this is happening. I increased the response time from the server

2) This code is written for win32, it would be better if the default values of options will generated for current system