### PR TITLE
added grunt test, more error handling, fixed timeout error, updated default, better kill

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,5 +30,6 @@ module.exports = function (grunt) {
 
   grunt.loadTasks('tasks');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.registerTask('test', ['start-selenium-server:test', 'stop-selenium-server:test']);
   grunt.registerTask('default', ['jshint']);
 };

--- a/tasks/selenium_server.js
+++ b/tasks/selenium_server.js
@@ -107,8 +107,14 @@ module.exports = function (grunt) {
 
     // Reading stream see if selenium has started
     function hasSeleniumStarted(data) {
-      if (data.toString().match(/Started SocketListener on .+:\d+/)) {
-        if (complete) return;
+      var str = data.toString();
+      if (str.match(/Selenium is already running/)) {
+        cb(new Error(str));
+      }
+      if (str.match(/Selenium Server is up and running/) || str.match(/Started SocketListener on .+:\d+/)) {
+        if (complete) {
+          return;
+        }
         grunt.log.ok('Selenium server SocketListener started.');
 
         // Wait a tiny bit more time just because it's java and I'm worried.
@@ -121,7 +127,7 @@ module.exports = function (grunt) {
 
     // < 2.43.0 outputs to stdout
     childProcesses[target].stdout.on('data', hasSeleniumStarted);
-    // >= 2.43.0 outputs to stdout
+    // >= 2.43.0 outputs to stderr
     childProcesses[target].stderr.on('data', hasSeleniumStarted);
 
     // Timeout case
@@ -144,7 +150,7 @@ module.exports = function (grunt) {
 
     // Set default options.
     var options = this.options({
-      downloadUrl: 'https://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.2.jar',
+      downloadUrl: 'https://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar',
       downloadLocation: os.tmpdir(),
       serverOptions: {},
       systemProperties: {}
@@ -183,7 +189,7 @@ module.exports = function (grunt) {
     }
     else {
       grunt.log.ok('Sending kill signal to child process.');
-      childProcesses[target].kill('SIGTERM');
+      childProcesses[target].kill('SIGINT');
     }
   });
 };


### PR DESCRIPTION
-added 'grunt test' task that starts and stops the selenium server (start-selenium-server, stop-selenium-server)

-added check for 'Selenium is already running' error message

-Issue 13: fixed timeout error by checking for new 'Selenium Server is up and running' message

-updated default download to version 2.46

-changed kill signal to 'SIGINT' for better compatibility https://nodejs.org/api/process.html#process_signal_events