### PR TITLE
Process exit hooks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,10 @@ module.exports = function (grunt) {
 
   grunt.loadTasks('tasks');
   grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.registerTask('test', ['start-selenium-server:test', 'stop-selenium-server:test']);
+  grunt.registerTask('test', ['start-selenium-server', 'stop-selenium-server']);
+  grunt.registerTask('test-autostop', function() {
+    grunt.config.set('start-selenium-server.test.options.autostop', true);
+    grunt.task.run('start-selenium-server');
+  });
   grunt.registerTask('default', ['jshint']);
 };

--- a/README.md
+++ b/README.md
@@ -2,42 +2,41 @@
 
 > Start/stop a local Selenium standalon server.
 
-
-
 ## Getting Started
 
 ```shell
 npm install grunt-selenium-server --save-dev
 ```
 
-```js
-grunt.loadNpmTasks('grunt-selenium-server');
-```
-
-
 Grunt config example (with default options):
 ```js
-'start-selenium-server': {
-  dev: {
-    options: {
-      downloadUrl: 'https://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.2.jar',
-      downloadLocation: '/tmp',
-      serverOptions: {},
-      systemProperties: {}
+module.exports = function (grunt) {
+  grunt.loadNpmTasks('grunt-selenium-server');
+  grunt.initConfig({
+    'start-selenium-server': {
+      dev: {
+        options: {
+          autostop: false,
+          downloadUrl: 'https://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar',
+          downloadLocation: os.tmpdir(),
+          serverOptions: {},
+          systemProperties: {}
+        }
+      }
+    },
+    'stop-selenium-server': {
+      dev: {}
     }
-  }
-},
-'stop-selenium-server': {
-  dev: {
-
-  }
-}
+  });
+};
 ```
+
+## Running grunt-selenium-server
 
 Grunt task example:
 ```js
-grunt.registerTask('devUI', 'run selenium server and phpunit', function(){
-   grunt.task.run(['start-selenium-server:dev', 'phpunit:dev', 'stop-selenium-server:dev']);
+grunt.registerTask('devUI', 'run selenium server and phpunit', function() {
+  grunt.task.run('start-selenium-server:dev', 'phpunit:dev', 'stop-selenium-server:dev');
 });
 ```
 
@@ -46,32 +45,56 @@ Run:
 grunt devUI
 ```
 
+## Stopping grunt-selenium-server
+
+Selenium will need to be stopped after it has started.
+
+**Set the `autostop` option to `true`**
+
+The selenium proccess will stop when the grunt proccess ends.
+```js
+'start-selenium-server': {
+  dev: {
+    options: {
+      autostop: true,
+      downloadUrl: 'https://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar'
+    }
+  }
+}
+```
+
+**Use [grunt-force-task](https://github.com/floriangosse/grunt-force-task) to force a task**
+
+Any tasks (expected) to fail will continue
+```js
+grunt.registerTask('test', ['start-selenium-server:dev', 'force:mochaTest', 'stop-selenium-server:dev']);
+```
+
+**Create custom grunt.fail handler**
 
 Kill selenium in case your grunt tasks fails before we reach 'stop-selenium-server':
 ```js
-        var seleniumChildProcesses = {};
-        grunt.event.on('selenium.start', function(target, process){
-            grunt.log.ok('Saw process for target: ' +  target);
-            seleniumChildProcesses[target] = process;
-        });
+var seleniumChildProcesses = {};
+grunt.event.on('selenium.start', function(target, process) {
+  grunt.log.ok('Saw process for target: ' +  target);
+  seleniumChildProcesses[target] = process;
+});
 
-        grunt.util.hooker.hook(grunt.fail, function(){
-            // Clean up selenium if we left it running after a failure.
-            grunt.log.writeln('Attempting to clean up running selenium server.');
-            for(var target in seleniumChildProcesses) {
-                grunt.log.ok('Killing selenium target: ' + target);
-                try {
-                    seleniumChildProcesses[target].kill('SIGTERM');
-                }
-                catch(e) {
-                    grunt.log.warn('Unable to stop selenium target: ' + target);
-                }
-            }
-        });
- ```
+grunt.util.hooker.hook(grunt.fail, function() {
+  // Clean up selenium if we left it running after a failure.
+  grunt.log.writeln('Attempting to clean up running selenium server.');
+  for (var target in seleniumChildProcesses) {
+    grunt.log.ok('Killing selenium target: ' + target);
+    try {
+      seleniumChildProcesses[target].kill('SIGINT');
+    } catch(e) {
+      grunt.log.warn('Unable to stop selenium target: ' + target);
+    }
+  }
+});
+```
 
-## Notes:
+#### Notes:
 1. If you won't handle this event, if your phpunit (for example) will fail the selenium server process will remain active in the background.
 
 2. The "grunt.fail" event will be fired whenever any grunt task is failing. Thus you might want to consider using a more specific event related to the task that actually uses selenium server. i.e phpunit in the above example.
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-selenium-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Grunt task to start/stop a local Selenium standalon server.",
   "main": "Gruntfile.js",
   "author": "Aaron Forsander",

--- a/tasks/selenium_server.js
+++ b/tasks/selenium_server.js
@@ -160,6 +160,7 @@ module.exports = function (grunt) {
 
     // Set default options.
     var options = this.options({
+      autostop: false,
       downloadUrl: 'https://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar',
       downloadLocation: os.tmpdir(),
       serverOptions: {},
@@ -185,6 +186,12 @@ module.exports = function (grunt) {
         done(true);
       });
     });
+
+    if (options.autostop) {
+      process.on('exit', kill);
+      process.on('SIGINT', kill);
+      process.on('uncaughtException', kill);
+    }
   });
 
   /**
@@ -202,8 +209,4 @@ module.exports = function (grunt) {
       childProcesses[target].kill('SIGINT');
     }
   });
-
-  process.on('exit', kill);
-  process.on('SIGINT', kill);
-  process.on('uncaughtException', kill);
 };

--- a/tasks/selenium_server.js
+++ b/tasks/selenium_server.js
@@ -1,19 +1,22 @@
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var url = require('url');
+var request = require('request');
+var ProgressBar = require('progress');
 
 module.exports = function (grunt) {
-
-  var fs = require('fs');
-  var os = require('os');
-  var path = require('path');
-  var url = require('url');
-  var request = require('request');
-  var ProgressBar = require('progress');
-
   /**
    * References running server processes.
    *
    * @type {Object}
    */
   var childProcesses = {};
+
+  function kill() {
+    for (target in childProcesses)
+      childProcesses[target].kill('SIGINT');
+  }
 
   /**
    * Download the Selenium Server jar file.
@@ -199,4 +202,8 @@ module.exports = function (grunt) {
       childProcesses[target].kill('SIGINT');
     }
   });
+
+  process.on('exit', kill);
+  process.on('SIGINT', kill);
+  process.on('uncaughtException', kill);
 };


### PR DESCRIPTION
Added process exit hooks (process.on exit, SIGINT and uncaughtException) that closes all child processes. This means stop-selenium-server does not HAVE to be called. Try this by running `grunt start-selenium-server` twice.