### PR TITLE
jar file is deleted if corrupt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+notifications:
+  email: false
+
+language: node_js
+
+node_js:
+  - "0.12"
+
+branches:
+  only:
+    - master
+
+before_script:
+  - "npm install"
+
+script: "npm test"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
   "author": "Aaron Forsander",
   "license": "MIT",
   "repository": "git@github.com:pifantastic/grunt-selenium-server.git",
-  "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.7.0",
-    "grunt-contrib-nodeunit": "~0.2.2"
-  },
   "dependencies": {
     "request": "~2.27.0",
     "progress": "~1.1.2"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-jshint": "~0.7.0",
+    "grunt-contrib-nodeunit": "~0.2.2"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-selenium-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Grunt task to start/stop a local Selenium standalon server.",
   "main": "Gruntfile.js",
   "author": "Aaron Forsander",


### PR DESCRIPTION
`start-selenium-server` will now delete the jar file if it is corrupt.

To test this run:
```
rm $TMPDIR/selenium-server-standalone-2.46.0.jar
grunt test
echo 'Broken file'>$TMPDIR/selenium-server-standalone-2.46.0.jar
grunt test
grunt test
```